### PR TITLE
Skip checking for circleci cli update

### DIFF
--- a/hooks/circleci-config-validate.sh
+++ b/hooks/circleci-config-validate.sh
@@ -17,7 +17,7 @@ if [[ -z $CIRCLECI ]]; then
 	[ -f /dev/tty ] && exec /dev/tty
 
 	# If validation fails, tell Git to stop and provide error message. Otherwise, continue.
-	if ! msg=$(circleci config validate "$@"); then
+	if ! msg=$(circleci config validate --skip-update-check "$@"); then
 		echo "CircleCI Configuration Failed Validation."
 		echo "$msg"
 		exit 1


### PR DESCRIPTION
This makes the execution of circleci cli faster when committing code. Without this option, `circleci` will reach out to the internet to see if there is a newer version of the CLI tool. This process can take a few seconds and makes it seem like the `git commit` process is broken.